### PR TITLE
gradle build에 Querydsl 추가

### DIFF
--- a/querydsl/build.gradle
+++ b/querydsl/build.gradle
@@ -1,12 +1,20 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.6.4'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
 group = 'com.study'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
+
 
 configurations {
     compileOnly {
@@ -25,8 +33,33 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //querydsl 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+//querydsl 추가 시작
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+//querydsl 추가 끝

--- a/querydsl/src/main/java/com/study/querydsl/controller/HelloController.java
+++ b/querydsl/src/main/java/com/study/querydsl/controller/HelloController.java
@@ -1,0 +1,13 @@
+package com.study.querydsl.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "hello";
+    }
+}

--- a/querydsl/src/main/java/com/study/querydsl/entity/Hello.java
+++ b/querydsl/src/main/java/com/study/querydsl/entity/Hello.java
@@ -1,0 +1,17 @@
+package com.study.querydsl.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Setter
+public class Hello {
+
+    @Id @GeneratedValue
+    private Long id;
+}

--- a/querydsl/src/test/java/com/study/querydsl/QuerydslApplicationTests.java
+++ b/querydsl/src/test/java/com/study/querydsl/QuerydslApplicationTests.java
@@ -1,13 +1,39 @@
 package com.study.querydsl;
 
+import org.assertj.core.api.Assertions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.study.querydsl.entity.Hello;
+import com.study.querydsl.entity.QHello;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+
 @SpringBootTest
+@Transactional
 class QuerydslApplicationTests {
 
+    @Autowired
+    EntityManager em;
     @Test
     void contextLoads() {
+
+        Hello hello = new Hello();
+        em.persist(hello);
+
+        JPAQueryFactory query = new JPAQueryFactory(em);
+        QHello qHello = new QHello("h");
+        //QHello qHello = QHello.hello; // static으로 만들어진게 있다.
+
+        Hello result = query
+                .selectFrom(qHello)
+                .fetchOne();
+
+        Assertions.assertThat(result).isEqualTo(hello);
+        Assertions.assertThat(result.getId()).isEqualTo(hello.getId());
+
     }
 
 }


### PR DESCRIPTION
- Spring Boot 2.6.x에선 Querydsl 5.0.0을 사용해야한다.
- 이렇게 추가해서 compileQuerydsl을 하게되면 Q타입의 QHello라는 클래스가 build 파일 아래에 생긴다.